### PR TITLE
update nodepool templates to add os disk type and availability zones

### DIFF
--- a/docs/2-managed-aks-cluster.md
+++ b/docs/2-managed-aks-cluster.md
@@ -31,6 +31,14 @@ az account show
 
 ```
 
+Create the `generated` directory for storing templated files if you have not done so already.
+
+```bash
+
+mkdir -p generated
+
+```
+
 ### Setup Service Principal and credentials
 
 An Azure Service Principal is needed for deploying Azure resources. The below instructions utilize [environment-based authentication](https://docs.microsoft.com/en-us/go/azure/azure-sdk-go-authorization#use-environment-based-authentication).
@@ -158,6 +166,10 @@ env | grep AZURE
 
     # update KUBECONFIG so kubectl can access the different config files.
     # useful for easily switching kube contexts
+    if [ ! "$KUBECONFIG" ];
+    then
+        export KUBECONFIG=~/.kube/config
+    fi
     export KUBECONFIG="${KUBECONFIG}:/workspaces/capi-in-codespaces/generated/${CLUSTER_NAME}.kubeconfig"
 
     # verify kubectl has access to the new context

--- a/docs/3-add-nodepool.md
+++ b/docs/3-add-nodepool.md
@@ -35,17 +35,24 @@ In this walktrhough, we will create new node pools in your existing AKS cluster 
       # There are a lot of SKU's for VM's and some are limited by region, for more information see https://learn.microsoft.com/en-us/azure/virtual-machines/sizes this tool is also avaliable for finding an appropriate SKU
       export POOL_MACHINE_SKU=Standard_A2_v2 # If not set defaults to Standard_A2_v2
       echo $POOL_MACHINE_SKU
+
       # Pool mode is used to designate node pool as a System or User node pool, acceptable values are User or System
       export POOL_MODE=User # If not set defaults to User
       echo $POOL_MODE
+
       # Pool disk size sets the disk size for the OS
       export POOL_DISK_SIZE=40 # If not set defaults to 30
       echo $POOL_DISK_SIZE
+
       # Pool min and max size sets parameters for autoscaler to use for minumum and maximum counts of nodes in the node pool
       export POOL_MIN_SIZE=1 # If not set defaults to 1
       export POOL_MAX_SIZE=2 # If not set defaults to 1
       echo $POOL_MIN_SIZE
       echo $POOL_MAX_SIZE
+
+      # Pool OS disk type is used to set the type of operating system disk for nodepool virtual machines. Acceptable values are Managed or Ephemeral.
+      export POOL_OS_DISK_TYPE=Managed # If not set defaults to Managed
+      echo $POOL_OS_DISK_TYPE
 
       ```
 

--- a/templates/aks-nodepool.yaml
+++ b/templates/aks-nodepool.yaml
@@ -32,3 +32,8 @@ spec:
   scaling:
     minSize: ${POOL_MIN_SIZE:=1}
     maxSize: ${POOL_MAX_SIZE:=2}
+  osDiskType: ${POOL_OS_DISK_TYPE:=Managed}
+  availabilityZones:
+  - "1"
+  - "2"
+  - "3"


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->

- Add availability zones and os disk type to nodepool template
- Make os disk type configurable and set default value to match AKS default
- Update kubeconfig section to make it work if user skipped the first lab by checking if the value has been set already

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1259
- Closes https://github.com/retaildevcrews/wcnp/issues/1260